### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,8 @@
 name: Pylint
 
+permissions:
+  contents: read
+
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/juanmunoz1986/NumericalAnalysis/security/code-scanning/1](https://github.com/juanmunoz1986/NumericalAnalysis/security/code-scanning/1)

The best way to fix the problem is to add an explicit `permissions` block to the root of the workflow. Since the workflow only needs to read repository contents to perform linting, we can set `contents: read` as the permission. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary `write` permissions.

The fix involves adding the following block:
```yaml
permissions:
  contents: read
```
This should be added after the `name` key and before the `on` key in the `.github/workflows/pylint.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
